### PR TITLE
Update Lando scaffold files

### DIFF
--- a/assets/.lando.base.yml
+++ b/assets/.lando.base.yml
@@ -1,7 +1,7 @@
 name: project-template
 recipe: drupal10
 config:
-  php: '8.1'
+  php: '8.3'
   webroot: web
   composer_version: 2-latest
   via: apache:2.4
@@ -19,8 +19,6 @@ services:
       environment:
         PHP_IDE_CONFIG: "serverName=appserver"
         DRUPAL_ENV: "lando"
-  database:
-    portforward: 58698
 
 tooling:
   site-install:

--- a/assets/settings.lando.php
+++ b/assets/settings.lando.php
@@ -11,14 +11,14 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 $settings['hash_salt'] = '1234';
 
 $databases['default']['default'] = [
-    'database' => 'drupal8',
+    'database' => 'drupal10',
     'driver' => 'mysql',
     'host' => 'database',
     'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-    'password' =>  'drupal8',
+    'password' =>  'drupal10',
     'port' => '3306',
     'prefix' => '',
-    'username' => 'drupal8'
+    'username' => 'drupal10'
 ];
 
 /**

--- a/composer.json
+++ b/composer.json
@@ -92,8 +92,8 @@
                 "[project-root]/.lando/scripts/lando-install.sh": {
                     "path": "assets/.lando/scripts/lando-install.sh"
                 },
-                "[project-root]/.lando.yml": {
-                    "path": "assets/.lando.yml"
+                "[project-root]/.lando.base.yml": {
+                    "path": "assets/.lando.base.yml"
                 },
                 "[project-root]/reference/.siteurl": {
                     "path": "assets/.siteurl",


### PR DESCRIPTION
The current Lando-related assets that get scaffolded/copied in every time a `composer` command is run within a project are out of date, leading to broken configs that need to be checked out/reverted regularly (and often mistakenly re-committed to project repos). This PR introduces a couple simple updates to bring the config in line with Lando convention and avoid breaking the DB connection in Lando environments.

- Updates Drupal settings to use the default "drupal10" DB credentials, as the drupal10 Lando recipe defaults to these instead of "drupal8" in the current settings file.
- Moves `.lando.yml` to `.lando.base.yml`.
  - Per the [docs](https://docs.lando.dev/core/v3/), an upstream Landofile can be defined that is used as a base upon which individual configs can be overwritten on a per-project basis. With the config as it was in the core `.lando.yml`, that only leaves room for a `.lando.local.yml` for overriding configs such as project name/domain, database port forwarding, component versions, etc. Generally `.lando.local.yml` files should not be committed under VCS, so this change allows for projects to have their own `.lando.yml` file for defining project specifics, and leaves open `.lando.local.yml` for individual developers' overrides.
- Removes the default DB port forwarding in the Landofile.
  - This lets port forwarding happen on a per-project or per-dev basis, which avoids conflicts if multiple projects are started on one machine and try to bind to the same port.
- Moves to PHP v8.3 to match current DDEV/Gitpod config.