### PR TITLE
Refactor Lando install scripts

### DIFF
--- a/assets/.lando.base.yml
+++ b/assets/.lando.base.yml
@@ -22,9 +22,12 @@ services:
 
 tooling:
   site-install:
-    service: appserver
     description: Runs composer install and drush site-install
-    cmd: /app/.lando/scripts/lando-install.sh
+    dir: /app
+    cmd:
+      - appserver: composer install
+      - database: .lando/scripts/lando-install-db.sh
+      - appserver: .lando/scripts/lando-install.sh
   app-update:
     service: appserver
     description: Updates outdated Drupal core and installed modules

--- a/assets/.lando.base.yml
+++ b/assets/.lando.base.yml
@@ -36,3 +36,10 @@ tooling:
       - composer update "drupal/*" drush/drush -W
       - drush updatedb
       - drush cr
+  reset-admin:
+    service: appserver
+    description: Sets the admin account username/password to "admin:admin" for local dev
+    cmd:
+      - drush sql-query "UPDATE users_field_data SET name='admin' WHERE uid=1";
+      - drush user:password admin "admin"
+      - drush cr

--- a/assets/.lando/scripts/lando-install-db.sh
+++ b/assets/.lando/scripts/lando-install-db.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+REF_FILE="sanitized.sql.gz"
+
+# Check if we are running this script from within the lando container
+# (e.g. via `lando site-install` or after entering `lando ssh`)
+# or from the host machine.
+if [ "$(which lando)" ]; then
+  LANDO='lando'
+  IN_CONTAINER=0
+else
+  LANDO=''
+  IN_CONTAINER=1
+fi
+
+if [ -f "${LANDO_MOUNT}/reference/${REF_FILE}" ]
+  then
+    echo "Reference database found. Importing..."
+    if [ $IN_CONTAINER -eq 1 ]; then
+      # Run container's built-in import helper
+      /helpers/sql-import.sh "${LANDO_MOUNT}/reference/${REF_FILE}"
+    else
+      # Call the lando script to import the database
+      $LANDO db-import "${LANDO_MOUNT}/reference/${REF_FILE}"
+    fi
+    if ! [ -f "web/sites/default/settings.php" ]
+      then
+        echo "Generating settings.php file..."
+        cp "web/sites/default/default.settings.php" "web/sites/default/settings.php"
+    fi
+  else
+    echo "No reference database found."
+    if [ $IN_CONTAINER -eq 1 ]; then
+      # We can't access the appserver service from here,
+      # direct the user towards next steps
+      echo "Please run .lando/scripts/site-install.sh from the host machine or appserver service."
+    else
+      # We can access all lando services from the host machine,
+      # go ahead and call the script
+      read -r -p "Run drush site-install? (y/N)? " answer
+          case ${answer:0:1} in
+              y|Y )
+                  $LANDO drush site-install -y
+              ;;
+              * )
+                  :
+              ;;
+          esac
+    fi
+fi


### PR DESCRIPTION
The current iteration of the Lando install script has some issues that prevent it from executing properly. Firstly it is set to search for a reference DB dump named `sanitized.sql`, while the current dumps are gzipped, so the script never finds the dump. Secondly, the script defaults to assuming that it is being run from the host machine when running actions. This would execute as expected when run from the host's project directory (e.g. `./.lando/scripts/lando-install.sh`), but when run via the Lando tooling (e.g. `lando site-install`) it is unable to run a db-import, both due to the missing alias name and the fact that the appserver service cannot directly talk to the database service.

This PR makes a couple of changes to split up the site install process and make sure that it can be run from the host machine or container/tooling properly:
- Install scripts are split up into one to run in the database service (searching for the reference db and importing it if found), and one for the appserver service (installing composer packages, running `drush site-install` if no reference DB is found, and importing site config).
- The Lando `site-install` tooling now individually runs the new scripts to install packages, attempt to import the DB (or initialize the site), and set up site config/admin creds.
- A new Lando tooling `reset-admin` exists to simply reset admin credentials. This can be useful if needing to regularly re-import the reference DB during active development.

It's overall still a tad messy, and may have some confusing language in certain cases (e.g. with no reference DB, calling the `site-install` tooling will show a message asking the user to manually run `site-install.sh`, but the tooling will run it afterwards anyway), but it should function cleanly.